### PR TITLE
Switch to relative link for URL to Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ This will output a `entropy.csv` file in the current directory with the average 
 
 Support
 -------
-If you have any questions, problems, or suggestions, please submit an [issue](https://github.com/GripQA/commit-entropy/issues) or contact us at support@grip.qa.
+If you have any questions, problems, or suggestions, please submit an [issue](../../issues) or contact us at support@grip.qa.


### PR DESCRIPTION
Hi @kmile-

The absolute link for issues works fine, but I can imagine situations where it could be an issue.

Although it doesn't apply directly since "/Issues" isn't one of our own sub-pages, this https://help.github.com/articles/relative-links-in-readmes/ suggests avoiding absolute URLs.

This pull request includes a relative link that also seems to work...
